### PR TITLE
Fixed program printing each non-verbal sound twice, and added the bolding of speaker names

### DIFF
--- a/transcript-back-end/sccParser.py
+++ b/transcript-back-end/sccParser.py
@@ -3,9 +3,11 @@ try:
 except ImportError:
     import subprocess
     import sys
+
     subprocess.check_call([sys.executable, "-m", "pip", "install", "pycaption"])
     from pycaption import SCCReader
-  
+
+
 def scc_to_html(input_file, output_file):
     with open(input_file, 'r') as f:
         scc_content = f.read()
@@ -20,6 +22,7 @@ def scc_to_html(input_file, output_file):
                 f.write(f'<p>{caption.get_text()}</p>\n')
         f.write('</body>\n</html>')
 
+
 def reformat_html(input_file, output_file):
     with open(input_file, 'r') as f:
         content = f.read()
@@ -31,13 +34,25 @@ def reformat_html(input_file, output_file):
     formatted_lines = []
     for line in lines:
         if line.startswith('<p>- '):
-            formatted_lines.append(line[5:])
+            if ':' in line:
+
+                # Formatting speaker names (bolding them)
+                formatted_line = line[5:]
+                split_index = formatted_line.find(':') + 1
+                first_part = formatted_line[:split_index]
+                second_part = formatted_line[split_index + 1:].strip()
+                first_part = f'<b>{first_part}</b>'
+                combined_string = first_part + " " + second_part
+                formatted_lines.append(combined_string)
+            else:
+                formatted_lines.append(line[5:])
         elif line.startswith('<p>['):
 
             # Formatting non-verbal sounds
             sound_text = line[3:-4]
-            formatted_lines.append(f'<p><i>{sound_text}</i></p>')
-            formatted_lines.append(line)
+            formatted_line = f'<p><i>{sound_text}</i></p>'
+            if formatted_line not in formatted_lines:  # Avoid duplicate entries
+                formatted_lines.append(formatted_line)
 
         elif line.startswith('<p>'):
             previous = formatted_lines[-1][:-4]
@@ -51,6 +66,7 @@ def reformat_html(input_file, output_file):
     # Write the formatted content to the output file
     with open(output_file, 'w') as f:
         f.write('\n'.join(formatted_lines))
+
 
 # generate the unformatted html file
 input_file = "../CaptionSamples/Sample1/2BAW0101HDST.scc"


### PR DESCRIPTION
When I first cloned the main branch, the output formatted HTML file showed each non-verbal sound twice (duplication), which obviously shouldn't happen. I fixed this with a few lines of code, so that it only shows it once (and it is italicized, as it should be). Finally, I also added a bunch of lines of code that bolded the speaker names.