### PR TITLE
Create simple API and update frontend to work with backend

### DIFF
--- a/transcript-back-end/api.py
+++ b/transcript-back-end/api.py
@@ -1,0 +1,17 @@
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route('/')
+def hello():
+    return 'Hello, World!'
+
+# Define your API endpoints here
+@app.route('/api/data', methods=['GET'])
+def get_data():
+    data = {'key': 'value'}
+    return jsonify(data)
+
+if __name__ == '__main__':
+    # Run the Flask app
+    app.run(debug=True)  # Debug mode allows you to see changes without restarting the server

--- a/transcript-back-end/api.py
+++ b/transcript-back-end/api.py
@@ -1,16 +1,28 @@
-from flask import Flask, jsonify
+from flask import Flask, request, jsonify, send_file
+from flask_cors import CORS
+from sccParser import scc_to_html, reformat_html
 
 app = Flask(__name__)
+CORS(app)
 
-@app.route('/')
-def hello():
-    return 'Hello, World!'
+@app.route('/api/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        return jsonify({"msg": "No file part in the request"}), 400
+    
+    file = request.files['file']
+    
+    if file:
+        input_file = 'input.scc'
+        output_file = 'output.html'
+        reformatted_file = 'reformat.html'
 
-# Define your API endpoints here
-@app.route('/api/data', methods=['GET'])
-def get_data():
-    data = {'key': 'value'}
-    return jsonify(data)
+        file.save(input_file)
+
+        scc_to_html(input_file, output_file)
+        reformat_html(output_file, reformatted_file)
+        
+        return send_file(reformatted_file, as_attachment=True)
 
 if __name__ == '__main__':
     # Run the Flask app

--- a/transcript-back-end/api.py
+++ b/transcript-back-end/api.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 from sccParser import scc_to_html, reformat_html
+from utils import is_allowed_file, get_extension
 
 app = Flask(__name__)
 CORS(app)
@@ -8,11 +9,18 @@ CORS(app)
 @app.route('/api/upload', methods=['POST'])
 def upload_file():
     if 'file' not in request.files:
-        return jsonify({"msg": "No file part in the request"}), 400
+        return jsonify({"msg": "No file attached in request."}), 400
     
     file = request.files['file']
+    file_name = file.filename
+
+    if not is_allowed_file(file_name):
+        return jsonify({"msg": "Included file was not in an accepted format."}), 415
     
-    if file:
+    if file and get_extension(file_name) == 'srt':
+        return jsonify({"msg": "SRT Parsing is not yet implemented."}), 501
+
+    if file and get_extension(file_name) == 'scc':
         input_file = 'input.scc'
         output_file = 'output.html'
         reformatted_file = 'reformat.html'
@@ -22,8 +30,7 @@ def upload_file():
         scc_to_html(input_file, output_file)
         reformat_html(output_file, reformatted_file)
         
-        return send_file(reformatted_file, as_attachment=True)
+        return send_file(reformatted_file, as_attachment=True), 200
 
 if __name__ == '__main__':
-    # Run the Flask app
-    app.run(debug=True)  # Debug mode allows you to see changes without restarting the server
+    app.run(debug=True)

--- a/transcript-back-end/api.py
+++ b/transcript-back-end/api.py
@@ -32,7 +32,7 @@ def upload_file():
         
         return send_file(reformatted_file, as_attachment=True), 200
 
-# This should be added in another ticket.
+# This should be added in another ticket (PBS-38).
 # It will make working with the transcript on the frontend much easier and allow us to add more features.
 @app.route('/api/upload-json', methods=['POST'])
 def upload_file_json():

--- a/transcript-back-end/api.py
+++ b/transcript-back-end/api.py
@@ -18,7 +18,7 @@ def upload_file():
         return jsonify({"msg": "Included file was not in an accepted format."}), 415
     
     if file and get_extension(file_name) == 'srt':
-        return jsonify({"msg": "SRT Parsing is not yet implemented."}), 501
+        return jsonify({"msg": "SRT parsing is not yet implemented."}), 501
 
     if file and get_extension(file_name) == 'scc':
         input_file = 'input.scc'
@@ -31,6 +31,12 @@ def upload_file():
         reformat_html(output_file, reformatted_file)
         
         return send_file(reformatted_file, as_attachment=True), 200
+
+# This should be added in another ticket.
+# It will make working with the transcript on the frontend much easier and allow us to add more features.
+@app.route('/api/upload-json', methods=['POST'])
+def upload_file_json():
+    return jsonify({"msg": "Caption file to JSON conversion is not yet implemented."}), 501
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/transcript-back-end/utils.py
+++ b/transcript-back-end/utils.py
@@ -1,0 +1,7 @@
+allowed_extensions = {'srt', 'scc'}
+
+def is_allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in allowed_extensions
+
+def get_extension(filename):
+    return filename.rsplit('.', 1)[1].lower()

--- a/transcript-front-end/src/App.css
+++ b/transcript-front-end/src/App.css
@@ -4,11 +4,11 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 33%; 
+    width: 40%; 
     transform: translate(-50%, -50%);
     padding: 15px;
-    padding-top: 25px; 
-    padding-bottom: 25px;
+    padding-top: 30px; 
+    padding-bottom: 30px;
     background-color: lightblue;
     box-shadow: 3px 3px 1px black;
 }

--- a/transcript-front-end/src/CurrentTranscriptContext.js
+++ b/transcript-front-end/src/CurrentTranscriptContext.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const CurrentTranscriptContext = createContext([]);
+
+export default CurrentTranscriptContext;

--- a/transcript-front-end/src/components/Navigation.jsx
+++ b/transcript-front-end/src/components/Navigation.jsx
@@ -1,7 +1,11 @@
+import { useState } from 'react';
 import { Navbar, Container, Nav } from 'react-bootstrap';
 import { Link, Outlet } from 'react-router-dom';
+import CurrentTranscriptContext from '../CurrentTranscriptContext';
 
 export default function Navigation() {
+
+    const [transcript, setTranscript] = useState(0);
 
     return (
         <div>
@@ -16,7 +20,9 @@ export default function Navigation() {
                 </Container>
             </Navbar>
             <div style={ { margin: "1rem" } }>
-                <Outlet />
+                <CurrentTranscriptContext.Provider value={[transcript, setTranscript]}>
+                    <Outlet />
+                </CurrentTranscriptContext.Provider>
             </div>
         </div>
     );

--- a/transcript-front-end/src/components/UploadPage.jsx
+++ b/transcript-front-end/src/components/UploadPage.jsx
@@ -1,13 +1,15 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { Button } from "react-bootstrap";
 import { Form } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
+import CurrentTranscriptContext from "../CurrentTranscriptContext";
 import '../App.css';
 
 export default function UploadPage(props) {
 
     const [file, setFile] = useState(0);
     const [fileFormatTextClass, setFileFormatTextClass] = useState("text-muted");
+    const [transcript, setTranscript] = useContext(CurrentTranscriptContext);
     const validFileFormats = ['srt', 'scc'];
     let navigator = useNavigate();
 
@@ -34,7 +36,7 @@ export default function UploadPage(props) {
             body: formData
         })
         .then(res => res.text())
-        .then(text => console.log(text))
+        .then(text => setTranscript(text))
 
         navigator("/viewer");
     }

--- a/transcript-front-end/src/components/UploadPage.jsx
+++ b/transcript-front-end/src/components/UploadPage.jsx
@@ -7,18 +7,25 @@ import '../App.css';
 export default function UploadPage(props) {
 
     const [file, setFile] = useState(0);
+    const [fileFormatTextClass, setFileFormatTextClass] = useState("text-muted");
+    const validFileFormats = ['srt', 'scc'];
     let navigator = useNavigate();
 
     const handleFileUpload = (e) => {
         e.preventDefault();
-        // May need to add a check here to make sure the file is an SCC or SRT file but this could also be done in the backend.
         const files = e.target.files;
-        setFile(files[0]);
+        const fileName = files[0].name;
+        if (validFileFormats.includes(fileName.split(".")[1])) {
+            setFileFormatTextClass("text-muted");
+            setFile(files[0]);
+        } else {
+            setFileFormatTextClass("text-danger");
+            setFile(0);
+        }
     }
 
     const handleSubmit = (e) => {
         e.preventDefault();
-
         const formData = new FormData();
         formData.append('file', file);
 
@@ -42,7 +49,7 @@ export default function UploadPage(props) {
                     <Form.Group>
                         <Form.Label style={ { marginBottom: "1.5rem" } }>Caption File</Form.Label>
                         <Form.Control type="file" className="caption-upload" onChange={handleFileUpload}></Form.Control>
-                        <Form.Text className="text-muted">Accepts only SRT and SCC caption files.</Form.Text>
+                        <Form.Text className={fileFormatTextClass}>Accepts only SRT and SCC caption files.</Form.Text>
                     </Form.Group>
                     <Button onClick={handleSubmit} variant="outline-dark" disabled={file == 0} style={ { marginTop: "1.5rem" } }>
                         Submit

--- a/transcript-front-end/src/components/UploadPage.jsx
+++ b/transcript-front-end/src/components/UploadPage.jsx
@@ -18,16 +18,17 @@ export default function UploadPage(props) {
 
     const handleSubmit = (e) => {
         e.preventDefault();
-        console.log(file);
-        /* This is where our API call would go and then we could 
-           send the returned JSON as a prop to the viewer page.
-        fetch('http://www.test.com', {
-            method: 'POST',
-            headers: {
-                "Content-Type": ""
-            },
-            body: file
-        }) */
+
+        const formData = new FormData();
+        formData.append('file', file);
+
+        fetch('http://localhost:5000/api/upload', {
+            method: "POST",
+            body: formData
+        })
+        .then(res => res.text())
+        .then(text => console.log(text))
+
         navigator("/viewer");
     }
 

--- a/transcript-front-end/src/components/Viewer.jsx
+++ b/transcript-front-end/src/components/Viewer.jsx
@@ -1,8 +1,18 @@
+import { useContext } from "react";
+import CurrentTranscriptContext from "../CurrentTranscriptContext";
+
 export default function Viewer(props) {
+
+    const [transcript, setTranscript] = useContext(CurrentTranscriptContext)
 
     return (
         <div>
             <h1>Transcript Viewer Page</h1>
+            {
+                transcript 
+                ? <div dangerouslySetInnerHTML={{ __html: transcript }} />
+                : <p>Please upload a caption file using the upload page.</p>
+            }
         </div>
     );
 

--- a/transcript-front-end/src/components/Viewer.jsx
+++ b/transcript-front-end/src/components/Viewer.jsx
@@ -5,6 +5,8 @@ export default function Viewer(props) {
 
     const [transcript, setTranscript] = useContext(CurrentTranscriptContext)
 
+    // We will need to update how the transcript is printed out once PBS-38 is finished.
+
     return (
         <div>
             <h1>Transcript Viewer Page</h1>


### PR DESCRIPTION
I created a single endpoint API that takes in an SCC or SRT file and returns an HTML document. This works for now but it would be ideal to decide on some way to jsonify the HTML document we created for two reasons.

1. Using setInnerHTML is bad practice.
2. We want to have more control on the frontend so that we can add features like changing font size, color, and highlighting based on timestamps.

I made another ticket for that (PBS-38) but we should definitely talk through how we want to format the JSON so that it is easy to read on the frontend and allows us to pack more data into the transcript.